### PR TITLE
3: Backfill tests for OTLP Resource Attributes

### DIFF
--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.trace.v1.Status;
 import wavefront.report.Annotation;
 import wavefront.report.Span;
 
@@ -97,6 +98,12 @@ public class OtlpTestHelpers {
   public static io.opentelemetry.proto.trace.v1.Span otlpSpanWithKind(
       io.opentelemetry.proto.trace.v1.Span.SpanKind kind) {
     return otlpSpanGenerator().setKind(kind).build();
+  }
+
+  public static io.opentelemetry.proto.trace.v1.Span otlpSpanWithStatus(Status.StatusCode code,
+                                                                        String message) {
+    Status status = Status.newBuilder().setCode(code).setMessage(message).build();
+    return otlpSpanGenerator().setStatus(status).build();
   }
 
   public static io.opentelemetry.proto.common.v1.KeyValue otlpAttribute(String key, String value) {

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
@@ -17,6 +17,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
 import wavefront.report.Annotation;
 import wavefront.report.Span;
 
@@ -95,6 +97,12 @@ public class OtlpTestHelpers {
   public static io.opentelemetry.proto.trace.v1.Span otlpSpanWithKind(
       io.opentelemetry.proto.trace.v1.Span.SpanKind kind) {
     return otlpSpanGenerator().setKind(kind).build();
+  }
+
+  public static io.opentelemetry.proto.common.v1.KeyValue otlpAttribute(String key, String value) {
+    return KeyValue.newBuilder().setKey(key).setValue(
+        AnyValue.newBuilder().setStringValue(value).build()
+    ).build();
   }
 
   public static Pair<ByteString, String> parentSpanIdPair() {


### PR DESCRIPTION
Add test to validate this logic:

If the Resource and Span both have an Attribute with the same name, the Attribute on the Span is the one that will be used in the resulting Wavefront Span – the value of the Resource's Attribute will not be used.