### PR TITLE
MONIT-26133: Set `source` from OTLP Resource

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -791,8 +791,8 @@ public class PushAgent extends AbstractAgent {
       activeListeners.inc();
       try {
         io.grpc.Server server = NettyServerBuilder.forPort(port).addService(
-            new OtlpGrpcTraceHandler(strPort, handlerFactory, wfSender,
-                preprocessors.get(strPort), sampler)
+            new OtlpGrpcTraceHandler(strPort, handlerFactory, wfSender, preprocessors.get(strPort),
+                sampler, proxyConfig.getHostname())
         )
             .build();
         server.start();
@@ -816,9 +816,10 @@ public class PushAgent extends AbstractAgent {
     //    registerTimestampFilter(strPort);
     //    if (proxyConfig.isHttpHealthCheckAllPorts()) healthCheckManager.enableHealthcheck(port);
 
-    ChannelHandler channelHandler = new OtlpHttpHandler(handlerFactory, tokenAuthenticator,
-        healthCheckManager,
-        strPort, wfSender, preprocessors.get(strPort), sampler);
+    ChannelHandler channelHandler = new OtlpHttpHandler(
+        handlerFactory, tokenAuthenticator, healthCheckManager, strPort, wfSender,
+        preprocessors.get(strPort), sampler, proxyConfig.getHostname()
+    );
 
     startAsManagedThread(port, new TcpIngester(createInitializer(channelHandler, port,
         proxyConfig.getPushListenerMaxReceivedLength(), proxyConfig.getPushListenerHttpBufferSize(),

--- a/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
@@ -225,7 +225,9 @@ public class OtlpProtobufUtils {
   public static List<Annotation> annotationsFromAttributes(List<KeyValue> attributesList) {
     List<Annotation> annotations = Lists.newArrayList();
     for (KeyValue attribute : attributesList) {
-      Annotation.Builder annotationBuilder = Annotation.newBuilder().setKey(attribute.getKey());
+      String key = attribute.getKey().equals(SOURCE_KEY) ? "_source" : attribute.getKey();
+      Annotation.Builder annotationBuilder = Annotation.newBuilder().setKey(key);
+
       if (!attribute.hasValue()) {
         annotationBuilder.setValue("");
       } else {
@@ -233,6 +235,7 @@ public class OtlpProtobufUtils {
       }
       annotations.add(annotationBuilder.build());
     }
+
     return annotations;
   }
 

--- a/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
@@ -8,13 +8,18 @@ import com.google.protobuf.ByteString;
 import com.wavefront.agent.handlers.ReportableEntityHandler;
 import com.wavefront.agent.listeners.tracing.SpanUtils;
 import com.wavefront.agent.preprocessor.ReportableEntityPreprocessor;
+import com.wavefront.common.Pair;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,6 +47,7 @@ import static com.wavefront.sdk.common.Constants.ERROR_TAG_KEY;
 import static com.wavefront.sdk.common.Constants.NULL_TAG_VAL;
 import static com.wavefront.sdk.common.Constants.SERVICE_TAG_KEY;
 import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SOURCE_KEY;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 
 /**
@@ -53,7 +59,6 @@ public class OtlpProtobufUtils {
   public final static String OTEL_STATUS_DESCRIPTION_KEY = "otel.status_description";
   private final static String DEFAULT_APPLICATION_NAME = "defaultApplication";
   private final static String DEFAULT_SERVICE_NAME = "defaultService";
-  private final static String DEFAULT_SOURCE = "otlp";
   private final static Logger OTLP_DATA_LOGGER = Logger.getLogger("OTLPDataLogger");
   private final static String SPAN_KIND_TAG_KEY = "span.kind";
   private final static HashMap<SpanKind, Annotation> SPAN_KIND_ANNOTATION_HASH_MAP =
@@ -69,15 +74,14 @@ public class OtlpProtobufUtils {
 
   public static void exportToWavefront(ExportTraceServiceRequest request,
                                        ReportableEntityHandler<Span, String> spanHandler,
-                                       @Nullable Supplier<ReportableEntityPreprocessor> preprocessorSupplier
-  ) {
+                                       @Nullable Supplier<ReportableEntityPreprocessor> preprocessorSupplier,
+                                       String defaultSource) {
     ReportableEntityPreprocessor preprocessor = null;
     if (preprocessorSupplier != null) {
       preprocessor = preprocessorSupplier.get();
     }
 
-    for (wavefront.report.Span wfSpan :
-        OtlpProtobufUtils.otlpSpanExportRequestParseToWFSpan(request, preprocessor)) {
+    for (wavefront.report.Span wfSpan : fromOtlpRequest(request, preprocessor, defaultSource)) {
       // TODO: handle sampler
       if (!wasFilteredByPreprocessor(wfSpan, spanHandler, preprocessor)) {
         spanHandler.report(wfSpan);
@@ -88,9 +92,11 @@ public class OtlpProtobufUtils {
   // TODO: consider transforming a single span and returning it for immedidate reporting in
   //   wfSender. This could be more efficient, and also more reliable in the event the loops
   //   below throw an error and we don't report any of the list.
-  private static List<Span> otlpSpanExportRequestParseToWFSpan(ExportTraceServiceRequest request,
-                                                               @Nullable ReportableEntityPreprocessor preprocessor) {
+  private static List<Span> fromOtlpRequest(ExportTraceServiceRequest request,
+                                            @Nullable ReportableEntityPreprocessor preprocessor,
+                                            String defaultSource) {
     List<Span> wfSpans = Lists.newArrayList();
+
     for (ResourceSpans resourceSpans : request.getResourceSpansList()) {
       Resource resource = resourceSpans.getResource();
       if (OTLP_DATA_LOGGER.isLoggable(Level.FINEST)) {
@@ -103,7 +109,8 @@ public class OtlpProtobufUtils {
               instrumentationLibrarySpans.getInstrumentationLibrary());
         }
         for (io.opentelemetry.proto.trace.v1.Span otlpSpan : instrumentationLibrarySpans.getSpansList()) {
-          wavefront.report.Span wfSpan = transform(otlpSpan, resource.getAttributesList(), preprocessor);
+          wavefront.report.Span wfSpan = transform(otlpSpan, resource.getAttributesList(),
+              preprocessor, defaultSource);
           if (OTLP_DATA_LOGGER.isLoggable(Level.FINEST)) {
             OTLP_DATA_LOGGER.info("Inbound OTLP Span: " + otlpSpan);
             OTLP_DATA_LOGGER.info("Converted Wavefront Span: " + wfSpan);
@@ -137,15 +144,23 @@ public class OtlpProtobufUtils {
     return false;
   }
 
+  @VisibleForTesting
   public static wavefront.report.Span transform(io.opentelemetry.proto.trace.v1.Span otlpSpan,
                                                 List<KeyValue> resourceAttrs,
-                                                ReportableEntityPreprocessor preprocessor) {
+                                                ReportableEntityPreprocessor preprocessor,
+                                                String defaultSource) {
+    Pair<String, List<KeyValue>> sourceAndResourceAttrs =
+        sourceFromAttributes(resourceAttrs, defaultSource);
+    String source = sourceAndResourceAttrs._1;
+    resourceAttrs = sourceAndResourceAttrs._2;
+
     // Order of arguments to Stream.of() matters: when a Resource Attribute and a Span Attribute
     // happen to share the same key, we want the Span Attribute to "win" and be preserved.
     List<KeyValue> otlpAttributes = Stream.of(resourceAttrs, otlpSpan.getAttributesList())
         .flatMap(Collection::stream).collect(Collectors.toList());
 
     List<Annotation> wfAnnotations = annotationsFromAttributes(otlpAttributes);
+
     wfAnnotations.add(SPAN_KIND_ANNOTATION_HASH_MAP.get(otlpSpan.getKind()));
     wfAnnotations.addAll(annotationsFromStatus(otlpSpan.getStatus()));
 
@@ -168,10 +183,10 @@ public class OtlpProtobufUtils {
         .setStartMillis(startTimeMs)
         .setDuration(durationMs)
         .setAnnotations(wfAnnotations)
-        // TODO: Check the precedence about the source tag
-        .setSource(DEFAULT_SOURCE)
+        .setSource(source)
         .setCustomer("dummy")
         .build();
+
     // apply preprocessor
     if (preprocessor != null) {
       preprocessor.forSpan().transform(toReturn);
@@ -181,6 +196,30 @@ public class OtlpProtobufUtils {
     List<Annotation> processedAnnotationList = setRequiredTags(toReturn.getAnnotations());
     toReturn.setAnnotations(processedAnnotationList);
     return toReturn;
+  }
+
+  // Returns a String of the source value and the original List<KeyValue> attributes except
+  // with the removal of the KeyValue determined to be the source.
+  @VisibleForTesting
+  public static Pair<String, List<KeyValue>> sourceFromAttributes(List<KeyValue> otlpAttributes,
+                                                                  String defaultSource) {
+    // Order of keys in List matters: it determines precedence when multiple candidates exist.
+    List<String> candidateKeys = Arrays.asList(SOURCE_KEY, "host.name", "hostname", "host.id");
+    Comparator<KeyValue> keySorter = Comparator.comparing(kv -> candidateKeys.indexOf(kv.getKey()));
+
+    Optional<KeyValue> sourceAttr = otlpAttributes.stream()
+        .filter(kv -> candidateKeys.contains(kv.getKey()))
+        .sorted(keySorter)
+        .findFirst();
+
+    if (sourceAttr.isPresent()) {
+      List<KeyValue> attributesWithoutSource = new ArrayList<>(otlpAttributes);
+      attributesWithoutSource.remove(sourceAttr.get());
+
+      return new Pair<>(fromAnyValue(sourceAttr.get().getValue()), attributesWithoutSource);
+    } else {
+      return new Pair<>(defaultSource, otlpAttributes);
+    }
   }
 
   public static List<Annotation> annotationsFromAttributes(List<KeyValue> attributesList) {

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -1466,12 +1466,13 @@ public class PushAgentTest {
   @Test
   public void testOtlpHttpPortHandler() throws Exception {
     port = findAvailablePort(4318);
+    proxy.proxyConfig.hostname = "defaultLocalHost";
     proxy.startOtlpHttpListener(String.valueOf(port), mockHandlerFactory, null, null);
     waitUntilListenerIsOnline(port);
 
     reset(mockTraceHandler);
 
-    Span wfSpan = OtlpTestHelpers.wfSpanGenerator(null).build();
+    Span wfSpan = OtlpTestHelpers.wfSpanGenerator(null).setSource("defaultLocalHost").build();
     mockTraceHandler.report(wfSpan);
     expectLastCall();
 

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
@@ -32,7 +32,7 @@ public class OtlpGrpcTraceHandlerTest {
     EasyMock.replay(mockSpanHandler);
 
     OtlpGrpcTraceHandler otlpGrpcTraceHandler = new OtlpGrpcTraceHandler("9876", mockSpanHandler,
-        null, null, null);
+        null, null, null, "test-source");
     ResourceSpans resourceSpans = ResourceSpans.newBuilder().
         addInstrumentationLibrarySpans(
             InstrumentationLibrarySpans.newBuilder().addSpans(otelSpan).build()

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
@@ -156,6 +156,20 @@ public class OtlpProtobufUtilsTest {
     }
 
     @Test
+    public void handlesSpecialCaseAnnotations() {
+      /*
+       A `source` tag at the span-level will override an explicit source that is set via
+       `wfSpanBuilder.setSource(...)`, which arguably seems like a bug. Since we determine the WF
+       source in `sourceAndResourceAttrs()`, rename any remaining OTLP Attribute to `_source`.
+       */
+      List<KeyValue> attrs = Collections.singletonList(otlpAttribute("source", "a-source"));
+
+      List<Annotation> actual = OtlpProtobufUtils.annotationsFromAttributes(attrs);
+
+      assertThat(actual, hasItem(new Annotation("_source", "a-source")));
+    }
+
+    @Test
     public void testRequiredTags() {
       List<Annotation> wfAnnotations = OtlpProtobufUtils.setRequiredTags(Collections.emptyList());
       Map<String, String> annotations = getWfAnnotationAsMap(wfAnnotations);
@@ -411,7 +425,7 @@ public class OtlpProtobufUtilsTest {
 
       assertEquals("a-src", actual.getSource());
       assertThat(actual.getAnnotations(), not(hasItem(new Annotation("source", "a-src"))));
-      assertThat(actual.getAnnotations(), hasItem(new Annotation("source", "span-level")));
+      assertThat(actual.getAnnotations(), hasItem(new Annotation("_source", "span-level")));
     }
 
     @Test

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
@@ -8,13 +8,13 @@ import com.wavefront.agent.handlers.ReportableEntityHandler;
 import com.wavefront.agent.preprocessor.ReportableEntityPreprocessor;
 import com.wavefront.common.Pair;
 
-import org.apache.commons.compress.utils.Lists;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -53,9 +53,12 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({OtlpProtobufUtilsTest.AnnotationAndAttributeTests.class,
+    OtlpProtobufUtilsTest.SourceFromAttributesTests.class,
     OtlpProtobufUtilsTest.TransformTests.class,
     OtlpProtobufUtilsTest.WasFilteredByPreprocessorTests.class})
 public class OtlpProtobufUtilsTest {
+
+  private final static List<KeyValue> emptyAttrs = Collections.unmodifiableList(new ArrayList<>());
 
   private static Map<String, String> getWfAnnotationAsMap(List<Annotation> wfAnnotations) {
     Map<String, String> wfAnnotationAsMap = Maps.newHashMap();
@@ -210,12 +213,20 @@ public class OtlpProtobufUtilsTest {
   }
 
   public static class TransformTests {
+
+    private wavefront.report.Span actual;
+
+    @Before
+    public void setup() {
+      actual = null;
+    }
+
     @Test
     public void transformsMinimalSpan() {
       Span otlpSpan = OtlpTestHelpers.otlpSpanGenerator().build();
       wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(null).build();
 
-      wavefront.report.Span actual = OtlpProtobufUtils.transform(otlpSpan, Lists.newArrayList(), null);
+      actual = OtlpProtobufUtils.transform(otlpSpan, emptyAttrs, null, "test-source");
 
       assertWFSpanEquals(expected, actual);
     }
@@ -225,7 +236,7 @@ public class OtlpProtobufUtilsTest {
       Span otlpSpan = OtlpTestHelpers.otlpSpanGenerator().setEndTimeUnixNano(0).build();
       wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(null).setDuration(0).build();
 
-      wavefront.report.Span actual = OtlpProtobufUtils.transform(otlpSpan, Lists.newArrayList(), null);
+      actual = OtlpProtobufUtils.transform(otlpSpan, emptyAttrs, null, "test-source");
 
       assertWFSpanEquals(expected, actual);
     }
@@ -244,22 +255,20 @@ public class OtlpProtobufUtilsTest {
       );
       wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(wfAttrs).build();
 
-      wavefront.report.Span actual = OtlpProtobufUtils.transform(otlpSpan, Lists.newArrayList(), null);
+      actual = OtlpProtobufUtils.transform(otlpSpan, emptyAttrs, null, "test-source");
 
       assertWFSpanEquals(expected, actual);
     }
 
     @Test
     public void convertsResourceAttributesToAnnotations() {
-      List<KeyValue> resourceAttrs = Collections.singletonList(
-          OtlpTestHelpers.otlpAttribute("rsrc-key", "rsrc-value")
-      );
+      List<KeyValue> resourceAttrs = Collections.singletonList(otlpAttribute("r-key", "r-value"));
       wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(
-          Collections.singletonList(new Annotation("rsrc-key", "rsrc-value"))
+          Collections.singletonList(new Annotation("r-key", "r-value"))
       ).build();
 
-      wavefront.report.Span actual = OtlpProtobufUtils.transform(
-          OtlpTestHelpers.otlpSpanGenerator().build(), resourceAttrs, null
+      actual = OtlpProtobufUtils.transform(
+          OtlpTestHelpers.otlpSpanGenerator().build(), resourceAttrs, null, "test-source"
       );
 
       assertWFSpanEquals(expected, actual);
@@ -272,7 +281,7 @@ public class OtlpProtobufUtilsTest {
           .addAttributes(otlpAttribute(key, "span-value")).build();
       List<KeyValue> resourceAttrs = Collections.singletonList(otlpAttribute(key, "rsrc-value"));
 
-      wavefront.report.Span actual = OtlpProtobufUtils.transform(otlpSpan, resourceAttrs, null);
+      actual = OtlpProtobufUtils.transform(otlpSpan, resourceAttrs, null, "test-source");
 
       assertThat(actual.getAnnotations(), not(hasItem(new Annotation(key, "rsrc-value"))));
       assertThat(actual.getAnnotations(), hasItem(new Annotation(key, "span-value")));
@@ -285,11 +294,10 @@ public class OtlpProtobufUtilsTest {
       List<Annotation> wfAttrs = Collections.singletonList(
           Annotation.newBuilder().setKey("my-key").setValue("my-value").build()
       );
-      wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(wfAttrs)
-          .build();
+      ReportableEntityPreprocessor preprocessor = OtlpTestHelpers.addTagIfNotExistsPreprocessor(wfAttrs);
+      wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(wfAttrs).build();
 
-      wavefront.report.Span actual = OtlpProtobufUtils.transform(otlpSpan, Lists.newArrayList(),
-          OtlpTestHelpers.addTagIfNotExistsPreprocessor(wfAttrs));
+      actual = OtlpProtobufUtils.transform(otlpSpan, emptyAttrs, preprocessor, "test-source");
 
       assertWFSpanEquals(expected, actual);
     }
@@ -300,11 +308,10 @@ public class OtlpProtobufUtilsTest {
       List<Annotation> wfAttrs = Collections.singletonList(
           Annotation.newBuilder().setKey(APPLICATION_TAG_KEY).setValue("an-app").build()
       );
-      wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(wfAttrs)
-          .build();
+      ReportableEntityPreprocessor preprocessor = OtlpTestHelpers.addTagIfNotExistsPreprocessor(wfAttrs);
+      wavefront.report.Span expected = OtlpTestHelpers.wfSpanGenerator(wfAttrs).build();
 
-      wavefront.report.Span actual = OtlpProtobufUtils.transform(otlpSpan, Lists.newArrayList(),
-          OtlpTestHelpers.addTagIfNotExistsPreprocessor(wfAttrs));
+      actual = OtlpProtobufUtils.transform(otlpSpan, emptyAttrs, preprocessor, "test-source");
 
       assertWFSpanEquals(expected, actual);
     }
@@ -313,50 +320,48 @@ public class OtlpProtobufUtilsTest {
     public void transformTranslatesSpanKindToAnnotation() {
       wavefront.report.Span clientSpan = OtlpProtobufUtils.transform(
           OtlpTestHelpers.otlpSpanWithKind(Span.SpanKind.SPAN_KIND_CLIENT),
-          Collections.emptyList(), null);
+          emptyAttrs, null, "test-source");
       assertThat(clientSpan.getAnnotations(), hasItem(new Annotation("span.kind", "client")));
 
       wavefront.report.Span consumerSpan = OtlpProtobufUtils.transform(
           OtlpTestHelpers.otlpSpanWithKind(Span.SpanKind.SPAN_KIND_CONSUMER),
-          Collections.emptyList(), null);
+          emptyAttrs, null, "test-source");
       assertThat(consumerSpan.getAnnotations(), hasItem(new Annotation("span.kind", "consumer")));
 
       wavefront.report.Span internalSpan = OtlpProtobufUtils.transform(
           OtlpTestHelpers.otlpSpanWithKind(Span.SpanKind.SPAN_KIND_INTERNAL),
-          Collections.emptyList(), null);
+          emptyAttrs, null, "test-source");
       assertThat(internalSpan.getAnnotations(), hasItem(new Annotation("span.kind", "internal")));
 
       wavefront.report.Span producerSpan = OtlpProtobufUtils.transform(
           OtlpTestHelpers.otlpSpanWithKind(Span.SpanKind.SPAN_KIND_PRODUCER),
-          Collections.emptyList(), null);
+          emptyAttrs, null, "test-source");
       assertThat(producerSpan.getAnnotations(), hasItem(new Annotation("span.kind", "producer")));
 
       wavefront.report.Span serverSpan = OtlpProtobufUtils.transform(
           OtlpTestHelpers.otlpSpanWithKind(Span.SpanKind.SPAN_KIND_SERVER),
-          Collections.emptyList(), null);
+          emptyAttrs, null, "test-source");
       assertThat(serverSpan.getAnnotations(), hasItem(new Annotation("span.kind", "server")));
 
       wavefront.report.Span unspecifiedSpan = OtlpProtobufUtils.transform(
           OtlpTestHelpers.otlpSpanWithKind(Span.SpanKind.SPAN_KIND_UNSPECIFIED),
-          Collections.emptyList(), null);
+          emptyAttrs, null, "test-source");
       assertThat(unspecifiedSpan.getAnnotations(),
           hasItem(new Annotation("span.kind", "unspecified")));
 
       wavefront.report.Span noKindSpan = OtlpProtobufUtils.transform(
           OtlpTestHelpers.otlpSpanGenerator().build(),
-          Collections.emptyList(), null);
+          emptyAttrs, null, "test-source");
       assertThat(noKindSpan.getAnnotations(),
           hasItem(new Annotation("span.kind", "unspecified")));
     }
 
     @Test
     public void handlesSpanStatusIfError() {
-      wavefront.report.Span actual;
-
       // Error Status without Message
       Span errorSpan = OtlpTestHelpers.otlpSpanWithStatus(Status.StatusCode.STATUS_CODE_ERROR, "");
 
-      actual = OtlpProtobufUtils.transform(errorSpan, Collections.emptyList(), null);
+      actual = OtlpProtobufUtils.transform(errorSpan, emptyAttrs, null, "test-source");
 
       assertThat(actual.getAnnotations(), hasItem(new Annotation(ERROR_TAG_KEY, ERROR_SPAN_TAG_VAL)));
       assertFalse(actual.getAnnotations().stream()
@@ -366,7 +371,7 @@ public class OtlpProtobufUtilsTest {
       Span errorSpanWithMessage = OtlpTestHelpers.otlpSpanWithStatus(
           Status.StatusCode.STATUS_CODE_ERROR, "a description");
 
-      actual = OtlpProtobufUtils.transform(errorSpanWithMessage, Collections.emptyList(), null);
+      actual = OtlpProtobufUtils.transform(errorSpanWithMessage, emptyAttrs, null, "test-source");
 
       assertThat(actual.getAnnotations(), hasItem(new Annotation(ERROR_TAG_KEY, ERROR_SPAN_TAG_VAL)));
       assertThat(actual.getAnnotations(),
@@ -375,12 +380,10 @@ public class OtlpProtobufUtilsTest {
 
     @Test
     public void ignoresSpanStatusIfNotError() {
-      wavefront.report.Span actual;
-
       // Ok Status
       Span okSpan = OtlpTestHelpers.otlpSpanWithStatus(Status.StatusCode.STATUS_CODE_OK, "");
 
-      actual = OtlpProtobufUtils.transform(okSpan, Collections.emptyList(), null);
+      actual = OtlpProtobufUtils.transform(okSpan, emptyAttrs, null, "test-source");
 
       assertFalse(actual.getAnnotations().stream()
           .anyMatch(annotation -> annotation.getKey().equals(ERROR_TAG_KEY)));
@@ -390,12 +393,34 @@ public class OtlpProtobufUtilsTest {
       // Unset Status
       Span unsetSpan = OtlpTestHelpers.otlpSpanWithStatus(Status.StatusCode.STATUS_CODE_UNSET, "");
 
-      actual = OtlpProtobufUtils.transform(unsetSpan, Collections.emptyList(), null);
+      actual = OtlpProtobufUtils.transform(unsetSpan, emptyAttrs, null, "test-source");
 
       assertFalse(actual.getAnnotations().stream()
           .anyMatch(annotation -> annotation.getKey().equals(ERROR_TAG_KEY)));
       assertFalse(actual.getAnnotations().stream()
           .anyMatch(annotation -> annotation.getKey().equals(OTEL_STATUS_DESCRIPTION_KEY)));
+    }
+
+    @Test
+    public void sourceSetFromResourceAttributesNotSpanAttributes() {
+      List<KeyValue> resourceAttrs = Collections.singletonList(otlpAttribute("source", "a-src"));
+      Span otlpSpan = OtlpTestHelpers.otlpSpanGenerator()
+          .addAttributes(otlpAttribute("source", "span-level")).build();
+
+      actual = OtlpProtobufUtils.transform(otlpSpan, resourceAttrs, null, "ignored");
+
+      assertEquals("a-src", actual.getSource());
+      assertThat(actual.getAnnotations(), not(hasItem(new Annotation("source", "a-src"))));
+      assertThat(actual.getAnnotations(), hasItem(new Annotation("source", "span-level")));
+    }
+
+    @Test
+    public void sourceHasDefaultWhenNoAttributesMatch() {
+      Span otlpSpan = OtlpTestHelpers.otlpSpanGenerator().build();
+
+      actual = OtlpProtobufUtils.transform(otlpSpan, emptyAttrs, null, "defaultSource");
+
+      assertEquals("defaultSource", actual.getSource());
     }
   }
 
@@ -438,6 +463,75 @@ public class OtlpProtobufUtilsTest {
       assertTrue(OtlpProtobufUtils.wasFilteredByPreprocessor(wfSpan, mockSpanHandler,
           preprocessor));
       EasyMock.verify(mockSpanHandler);
+    }
+  }
+
+  public static class SourceFromAttributesTests {
+    @Test
+    public void sourceSetAccordingToPrecedenceRules() {
+      Pair<String, List<KeyValue>> actual;
+
+      // "source" attribute has highest precedence
+      actual = OtlpProtobufUtils.sourceFromAttributes(
+          Arrays.asList(
+              otlpAttribute("hostname", "a-hostname"),
+              otlpAttribute("host.id", "a-host.id"),
+              otlpAttribute("source", "a-src"),
+              otlpAttribute("host.name", "a-host.name")
+          ), "ignore");
+      assertEquals("a-src", actual._1);
+
+      // "host.name" next highest
+      actual = OtlpProtobufUtils.sourceFromAttributes(
+          Arrays.asList(
+              otlpAttribute("hostname", "a-hostname"),
+              otlpAttribute("host.id", "a-host.id"),
+              otlpAttribute("host.name", "a-host.name")
+          ), "ignore");
+      assertEquals("a-host.name", actual._1);
+
+      // "hostname" next highest
+      actual = OtlpProtobufUtils.sourceFromAttributes(
+          Arrays.asList(
+              otlpAttribute("hostname", "a-hostname"),
+              otlpAttribute("host.id", "a-host.id")
+          ), "ignore");
+      assertEquals("a-hostname", actual._1);
+
+      // "host.id" has lowest precedence
+      actual = OtlpProtobufUtils.sourceFromAttributes(
+          Arrays.asList(otlpAttribute("host.id", "a-host.id")), "ignore"
+      );
+      assertEquals("a-host.id", actual._1);
+    }
+
+    @Test
+    public void defaultUsedWhenNoCandidateExists() {
+      Pair<String, List<KeyValue>> actual = OtlpProtobufUtils.sourceFromAttributes(
+          emptyAttrs, "a-default"
+      );
+
+      assertEquals("a-default", actual._1);
+      assertEquals(emptyAttrs, actual._2);
+    }
+
+    @Test
+    public void deletesCandidateUsedAsSource() {
+      List<KeyValue> attrs = Arrays.asList(
+          otlpAttribute("hostname", "a-hostname"),
+          otlpAttribute("some-key", "some-val"),
+          otlpAttribute("host.id", "a-host.id")
+      );
+
+      Pair<String, List<KeyValue>> actual = OtlpProtobufUtils.sourceFromAttributes(attrs, "ignore");
+
+      assertEquals("a-hostname", actual._1);
+
+      List<KeyValue> expectedAttrs = Arrays.asList(
+          otlpAttribute("some-key", "some-val"),
+          otlpAttribute("host.id", "a-host.id")
+      );
+      assertEquals(expectedAttrs, actual._2);
     }
   }
 }

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
@@ -82,7 +82,7 @@ public class OtlpTestHelpers {
         .setStartMillis(startTimeMs)
         .setDuration(durationMs)
         .setAnnotations(annotations)
-        .setSource(DEFAULT_SOURCE)
+        .setSource("test-source")
         .setCustomer("dummy");
   }
 
@@ -133,7 +133,7 @@ public class OtlpTestHelpers {
     PreprocessorRuleMetrics preprocessorRuleMetrics = new PreprocessorRuleMetrics(null, null,
         null);
     preprocessor.forSpan().addFilter(new SpanBlockFilter(
-        "sourceName", DEFAULT_SOURCE, x -> true, preprocessorRuleMetrics));
+        "sourceName", "test-source", x -> true, preprocessorRuleMetrics));
 
     return preprocessor;
   }


### PR DESCRIPTION
Precendence for determining `source` for WF Span is by looking at the
OTLP Resource Attributes for the following keys:

1. `source`
2. `host.name`
3. `hostname`
4. `host.id`

If none of those exist, a default value of proxyConfig.getHostname() is
used.