### PR TITLE
OTLP Listeners report RED Metrics and Heartbeats

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -27,6 +27,7 @@
     <java.version>1.8</java.version>
     <netty.version>4.1.71.Final</netty.version>
     <opentelemetry.version>1.6.0-alpha</opentelemetry.version>
+    <powermock.version>2.0.9</powermock.version>
 
     <doclint>none</doclint>
   </properties>
@@ -617,6 +618,18 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <version>4.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -792,9 +792,8 @@ public class PushAgent extends AbstractAgent {
       try {
         io.grpc.Server server = NettyServerBuilder.forPort(port).addService(
             new OtlpGrpcTraceHandler(strPort, handlerFactory, wfSender, preprocessors.get(strPort),
-                sampler, proxyConfig.getHostname())
-        )
-            .build();
+                sampler, proxyConfig.getHostname(), proxyConfig.getTraceDerivedCustomTagKeys())
+        ).build();
         server.start();
       } catch (Exception e) {
         logger.log(Level.SEVERE, "OTLP gRPC collector exception", e);
@@ -818,7 +817,8 @@ public class PushAgent extends AbstractAgent {
 
     ChannelHandler channelHandler = new OtlpHttpHandler(
         handlerFactory, tokenAuthenticator, healthCheckManager, strPort, wfSender,
-        preprocessors.get(strPort), sampler, proxyConfig.getHostname()
+        preprocessors.get(strPort), sampler, proxyConfig.getHostname(),
+        proxyConfig.getTraceDerivedCustomTagKeys()
     );
 
     startAsManagedThread(port, new TcpIngester(createInitializer(channelHandler, port,

--- a/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -195,9 +196,9 @@ public class OtlpProtobufUtils {
 
     String wfSpanId = SpanUtils.toStringId(otlpSpan.getSpanId());
     String wfTraceId = SpanUtils.toStringId(otlpSpan.getTraceId());
-    long startTimeMs = otlpSpan.getStartTimeUnixNano() / 1000;
+    long startTimeMs = TimeUnit.NANOSECONDS.toMillis(otlpSpan.getStartTimeUnixNano());
     long durationMs = otlpSpan.getEndTimeUnixNano() == 0 ? 0 :
-        (otlpSpan.getEndTimeUnixNano() - otlpSpan.getStartTimeUnixNano()) / 1000;
+        TimeUnit.NANOSECONDS.toMillis(otlpSpan.getEndTimeUnixNano() - otlpSpan.getStartTimeUnixNano());
 
     wavefront.report.Span toReturn = wavefront.report.Span.newBuilder()
         .setName(otlpSpan.getName())
@@ -228,7 +229,7 @@ public class OtlpProtobufUtils {
 
     for (io.opentelemetry.proto.trace.v1.Span.Event event : otlpSpan.getEventsList()) {
       SpanLog log = new SpanLog();
-      log.setTimestamp(event.getTimeUnixNano() / 1000);
+      log.setTimestamp(TimeUnit.NANOSECONDS.toMicros(event.getTimeUnixNano()));
       Map<String, String> fields = mapFromAttributes(event.getAttributesList());
       fields.put(SPAN_EVENT_TAG_KEY, event.getName());
       log.setFields(fields);

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -1470,14 +1470,15 @@ public class PushAgentTest {
   public void testOtlpHttpPortHandler() throws Exception {
     port = findAvailablePort(4318);
     proxy.proxyConfig.hostname = "defaultLocalHost";
-    proxy.startOtlpHttpListener(String.valueOf(port), mockHandlerFactory, null, null);
+    proxy.startOtlpHttpListener(String.valueOf(port), mockHandlerFactory, mockWavefrontSender, null);
     waitUntilListenerIsOnline(port);
 
-    reset(mockTraceHandler, mockTraceSpanLogsHandler);
-    Capture<wavefront.report.Span> actualSpan = Capture.newInstance();
-    Capture<wavefront.report.SpanLogs> actualLogs = Capture.newInstance();
+    reset(mockTraceHandler, mockTraceSpanLogsHandler, mockWavefrontSender);
+    Capture<wavefront.report.Span> actualSpan = EasyMock.newCapture();
+    Capture<wavefront.report.SpanLogs> actualLogs = EasyMock.newCapture();
     mockTraceHandler.report(capture(actualSpan));
     mockTraceSpanLogsHandler.report(capture(actualLogs));
+
     replay(mockTraceHandler, mockTraceSpanLogsHandler);
 
     io.opentelemetry.proto.trace.v1.Span.Event otlpEvent = OtlpTestHelpers.otlpSpanEvent();

--- a/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/PushAgentTest.java
@@ -1481,7 +1481,7 @@ public class PushAgentTest {
 
     replay(mockTraceHandler, mockTraceSpanLogsHandler);
 
-    io.opentelemetry.proto.trace.v1.Span.Event otlpEvent = OtlpTestHelpers.otlpSpanEvent();
+    io.opentelemetry.proto.trace.v1.Span.Event otlpEvent = OtlpTestHelpers.otlpSpanEvent(0);
     io.opentelemetry.proto.trace.v1.Span otlpSpan =
         OtlpTestHelpers.otlpSpanGenerator().addEvents(otlpEvent).build();
     ExportTraceServiceRequest otlpRequest = OtlpTestHelpers.otlpTraceRequest(otlpSpan);
@@ -1494,7 +1494,7 @@ public class PushAgentTest {
         .wfSpanGenerator(Arrays.asList(new Annotation("_spanLogs", "true")))
         .setSource("defaultLocalHost")
         .build();
-    SpanLogs expectedLogs = OtlpTestHelpers.wfSpanLogsGenerator(expectedSpan).build();
+    SpanLogs expectedLogs = OtlpTestHelpers.wfSpanLogsGenerator(expectedSpan, 0).build();
 
     OtlpTestHelpers.assertWFSpanEquals(expectedSpan, actualSpan.getValue());
     assertEquals(expectedLogs, actualLogs.getValue());

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
@@ -55,7 +55,7 @@ public class OtlpGrpcTraceHandlerTest {
 
     EasyMock.replay(mockSpanHandler, mockSpanLogsHandler, mockSender);
 
-    Span.Event otlpEvent = OtlpTestHelpers.otlpSpanEvent();
+    Span.Event otlpEvent = OtlpTestHelpers.otlpSpanEvent(0);
     Span otlpSpan = OtlpTestHelpers.otlpSpanGenerator().addEvents(otlpEvent).build();
     ExportTraceServiceRequest otlpRequest = OtlpTestHelpers.otlpTraceRequest(otlpSpan);
 
@@ -71,7 +71,7 @@ public class OtlpGrpcTraceHandlerTest {
     wavefront.report.Span expectedSpan =
         OtlpTestHelpers.wfSpanGenerator(Arrays.asList(new Annotation("_spanLogs", "true"))).build();
     wavefront.report.SpanLogs expectedLogs =
-        OtlpTestHelpers.wfSpanLogsGenerator(expectedSpan).build();
+        OtlpTestHelpers.wfSpanLogsGenerator(expectedSpan, 0).build();
 
     OtlpTestHelpers.assertWFSpanEquals(expectedSpan, actualSpan.getValue());
     assertEquals(expectedLogs, actualLogs.getValue());

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandlerTest.java
@@ -1,0 +1,93 @@
+package com.wavefront.agent.listeners.otlp;
+
+import com.wavefront.agent.handlers.MockReportableEntityHandlerFactory;
+import com.wavefront.agent.handlers.ReportableEntityHandler;
+import com.wavefront.agent.handlers.ReportableEntityHandlerFactory;
+import com.wavefront.sdk.common.WavefrontSender;
+
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import wavefront.report.Span;
+import wavefront.report.SpanLogs;
+
+import static com.wavefront.sdk.common.Constants.APPLICATION_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.CLUSTER_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.COMPONENT_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.HEART_BEAT_METRIC;
+import static com.wavefront.sdk.common.Constants.SERVICE_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link OtlpHttpHandler}.
+ *
+ * @author Glenn Oppegard (goppegard@vmware.com)
+ */
+
+public class OtlpHttpHandlerTest {
+  private final ReportableEntityHandler<Span, String> mockTraceHandler =
+      MockReportableEntityHandlerFactory.getMockTraceHandler();
+  private final ReportableEntityHandler<SpanLogs, String> mockSpanLogsHandler =
+      MockReportableEntityHandlerFactory.getMockTraceSpanLogsHandler();
+  private final WavefrontSender mockSender = EasyMock.createMock(WavefrontSender.class);
+  private final ReportableEntityHandlerFactory mockHandlerFactory =
+      MockReportableEntityHandlerFactory.createMockHandlerFactory(null, null, null,
+          mockTraceHandler, mockSpanLogsHandler, null);
+  private final ChannelHandlerContext mockCtx = EasyMock.createNiceMock(ChannelHandlerContext.class);
+
+  @Before
+  public void setup() {
+    EasyMock.reset(mockTraceHandler, mockSpanLogsHandler, mockSender, mockCtx);
+  }
+
+  @Test
+  public void testHeartbeatEmitted() throws Exception {
+    Capture<HashMap<String, String>> heartbeatTagsCapture = EasyMock.newCapture();
+    mockSender.sendMetric(eq(HEART_BEAT_METRIC), eq(1.0), anyLong(),
+        eq("defaultSource"), EasyMock.capture(heartbeatTagsCapture));
+    expectLastCall().times(2);
+    EasyMock.replay(mockSender, mockCtx);
+
+    OtlpHttpHandler handler = new OtlpHttpHandler(mockHandlerFactory, null, null, "4318",
+        mockSender, null, null, "defaultSource", null);
+    io.opentelemetry.proto.trace.v1.Span otlpSpan =
+        OtlpTestHelpers.otlpSpanGenerator().build();
+    ExportTraceServiceRequest otlpRequest = OtlpTestHelpers.otlpTraceRequest(otlpSpan);
+    ByteBuf body = Unpooled.copiedBuffer(otlpRequest.toByteArray());
+    HttpHeaders headers = new DefaultHttpHeaders().add("content-type", "application/x-protobuf");
+    FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+        "http://localhost:4318/v1/traces", body, headers, EmptyHttpHeaders.INSTANCE);
+
+    handler.handleHttpMessage(mockCtx, request);
+    handler.run();
+
+    EasyMock.verify(mockSender);
+    HashMap<String, String> actualHeartbeatTags = heartbeatTagsCapture.getValue();
+    assertEquals(6, actualHeartbeatTags.size());
+    assertEquals("defaultApplication", actualHeartbeatTags.get(APPLICATION_TAG_KEY));
+    assertEquals("none", actualHeartbeatTags.get(CLUSTER_TAG_KEY));
+    assertEquals("otlp", actualHeartbeatTags.get(COMPONENT_TAG_KEY));
+    assertEquals("defaultService", actualHeartbeatTags.get(SERVICE_TAG_KEY));
+    assertEquals("none", actualHeartbeatTags.get(SHARD_TAG_KEY));
+    assertEquals("none", actualHeartbeatTags.get("span.kind"));
+  }
+}

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
@@ -635,9 +635,10 @@ public class OtlpProtobufUtilsTest {
 
     assertThat(wfMinimalSpan.getAnnotations(), not(hasKey(ERROR_TAG_KEY)));
     assertThat(wfMinimalSpan.getAnnotations(), not(hasKey(COMPONENT_TAG_KEY)));
-    OtlpProtobufUtils.reportREDMetrics(wfMinimalSpan, anyObject(), anyObject());
+    OtlpProtobufUtils.reportREDMetrics(wfMinimalSpan, null, null);
 
     assertFalse(isError.getValue());
     assertEquals(NULL_TAG_VAL, componentTag.getValue());
+    PowerMock.verify(SpanDerivedMetricsUtils.class);
   }
 }

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
@@ -6,7 +6,7 @@ import com.wavefront.agent.preprocessor.PreprocessorRuleMetrics;
 import com.wavefront.agent.preprocessor.ReportableEntityPreprocessor;
 import com.wavefront.agent.preprocessor.SpanAddAnnotationIfNotExistsTransformer;
 import com.wavefront.agent.preprocessor.SpanBlockFilter;
-import com.wavefront.common.Pair;
+import com.wavefront.sdk.common.Pair;
 
 import org.apache.commons.compress.utils.Lists;
 import org.hamcrest.FeatureMatcher;

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpTestHelpers.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -94,7 +95,8 @@ public class OtlpTestHelpers {
   }
 
   public static SpanLogs.Builder wfSpanLogsGenerator(Span span) {
-    long logTimestamp = span.getStartMillis() + (span.getDuration() / 2);
+    long logTimestamp =
+        TimeUnit.MILLISECONDS.toMicros(span.getStartMillis() + (span.getDuration() / 2));
     Map<String, String> logFields = new HashMap<String, String>() {{
       put("name", "eventName");
       put("attrKey", "attrValue");
@@ -114,8 +116,8 @@ public class OtlpTestHelpers {
         .setName("root")
         .setSpanId(ByteString.copyFrom(spanIdBytes))
         .setTraceId(ByteString.copyFrom(traceIdBytes))
-        .setStartTimeUnixNano(startTimeMs * 1000)
-        .setEndTimeUnixNano((startTimeMs + durationMs) * 1000);
+        .setStartTimeUnixNano(TimeUnit.MILLISECONDS.toNanos(startTimeMs))
+        .setEndTimeUnixNano(TimeUnit.MILLISECONDS.toNanos(startTimeMs + durationMs));
   }
 
   public static io.opentelemetry.proto.trace.v1.Span otlpSpanWithKind(
@@ -136,7 +138,7 @@ public class OtlpTestHelpers {
   }
 
   public static io.opentelemetry.proto.trace.v1.Span.Event otlpSpanEvent() {
-    long eventTimestamp = (startTimeMs + (durationMs / 2)) * 1_000;
+    long eventTimestamp = TimeUnit.MILLISECONDS.toNanos(startTimeMs + (durationMs / 2));
     KeyValue attr = otlpAttribute("attrKey", "attrValue");
     return io.opentelemetry.proto.trace.v1.Span.Event.newBuilder()
         .setName("eventName")


### PR DESCRIPTION
This adds support for reporting span RED metrics and the `component.heartbeat` metric, used in the distributed tracing Application Map.

The big changes in `OtlpProtobufUtilsTest` are mostly noise that can be ignored: the changes are due to removing JUnit `@RunWith(Suite.class)` and the nested classes. This was required for the PowerMock annotations to work correctly when running an isolated test.