### PR TITLE
OTLP Trace Listeners report internal metrics

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/FeatureCheckUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/FeatureCheckUtils.java
@@ -71,13 +71,50 @@ public abstract class FeatureCheckUtils {
                                           @Nullable Counter discardedCounter,
                                           @Nullable StringBuilder output,
                                           @Nullable FullHttpRequest request) {
+    return isFeatureDisabled(featureDisabledFlag, message, discardedCounter, 1, output, request);
+  }
+
+  /**
+   * Check whether feature disabled flag is set, log a warning message, increment the counter by
+   * increment.
+   *
+   * @param featureDisabledFlag Supplier for feature disabled flag.
+   * @param message             Warning message to log if feature is disabled.
+   * @param discardedCounter    Counter for discarded items.
+   * @param increment           The amount by which the counter will be increased.
+   * @return true if feature is disabled
+   */
+  public static boolean isFeatureDisabled(Supplier<Boolean> featureDisabledFlag,
+                                          String message,
+                                          Counter discardedCounter,
+                                          long increment) {
+    return isFeatureDisabled(featureDisabledFlag, message, discardedCounter, increment, null, null);
+  }
+
+  /**
+   * Check whether feature disabled flag is set, log a warning message, increment the counter
+   * either by increment or by number of \n characters in request payload, if provided.
+   *
+   * @param featureDisabledFlag Supplier for feature disabled flag.
+   * @param message             Warning message to log if feature is disabled.
+   * @param discardedCounter    Optional counter for discarded items.
+   * @param increment           The amount by which the counter will be increased.
+   * @param output              Optional stringbuilder for messages
+   * @param request             Optional http request to use payload size
+   * @return true if feature is disabled
+   */
+  public static boolean isFeatureDisabled(Supplier<Boolean> featureDisabledFlag, String message,
+                                          @Nullable Counter discardedCounter,
+                                          long increment,
+                                          @Nullable StringBuilder output,
+                                          @Nullable FullHttpRequest request) {
     if (featureDisabledFlag.get()) {
       featureDisabledLogger.warning(message);
       if (output != null) {
         output.append(message);
       }
       if (discardedCounter != null) {
-        discardedCounter.inc(request == null ? 1 :
+        discardedCounter.inc(request == null ? increment :
             StringUtils.countMatches(request.content().toString(CharsetUtil.UTF_8), "\n") + 1);
       }
       return true;

--- a/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandler.java
@@ -1,5 +1,6 @@
 package com.wavefront.agent.listeners.otlp;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 
 import com.wavefront.agent.handlers.HandlerKey;
@@ -28,6 +29,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
@@ -35,6 +37,8 @@ import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import wavefront.report.Span;
 import wavefront.report.SpanLogs;
 
+import static com.wavefront.agent.listeners.FeatureCheckUtils.SPAN_DISABLED;
+import static com.wavefront.agent.listeners.FeatureCheckUtils.isFeatureDisabled;
 import static com.wavefront.internal.SpanDerivedMetricsUtils.TRACING_DERIVED_PREFIX;
 import static com.wavefront.internal.SpanDerivedMetricsUtils.reportHeartbeats;
 
@@ -47,30 +51,43 @@ public class OtlpGrpcTraceHandler extends TraceServiceGrpc.TraceServiceImplBase 
   private final WavefrontSender wfSender;
   private final Supplier<ReportableEntityPreprocessor> preprocessorSupplier;
   private final Pair<SpanSampler, Counter> spanSamplerAndCounter;
+  private final Pair<Supplier<Boolean>, Counter> spansDisabled;
+  private final Pair<Supplier<Boolean>, Counter> spanLogsDisabled;
   private final String defaultSource;
   private final WavefrontInternalReporter internalReporter;
   private final Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics;
   private final Set<String> traceDerivedCustomTagKeys;
   private final ScheduledExecutorService scheduledExecutorService;
+  private final Counter receivedSpans;
 
 
+  @VisibleForTesting
   public OtlpGrpcTraceHandler(String handle,
                               ReportableEntityHandler<Span, String> spanHandler,
                               ReportableEntityHandler<SpanLogs, String> spanLogsHandler,
                               @Nullable WavefrontSender wfSender,
                               @Nullable Supplier<ReportableEntityPreprocessor> preprocessorSupplier,
                               SpanSampler sampler,
+                              Supplier<Boolean> spansFeatureDisabled,
+                              Supplier<Boolean> spanLogsFeatureDisabled,
                               String defaultSource,
                               Set<String> traceDerivedCustomTagKeys) {
     this.spanHandler = spanHandler;
     this.spanLogsHandler = spanLogsHandler;
     this.wfSender = wfSender;
     this.preprocessorSupplier = preprocessorSupplier;
-    this.spanSamplerAndCounter = Pair.of(sampler,
-        Metrics.newCounter(new MetricName("spans." + handle, "", "sampler.discarded")));
     this.defaultSource = defaultSource;
     this.traceDerivedCustomTagKeys = traceDerivedCustomTagKeys;
+
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
+    this.receivedSpans = Metrics.newCounter(new MetricName("spans." + handle, "", "received.total"));
+    this.spanSamplerAndCounter = Pair.of(sampler,
+        Metrics.newCounter(new MetricName("spans." + handle, "", "sampler.discarded")));
+    this.spansDisabled = Pair.of(spansFeatureDisabled,
+        Metrics.newCounter(new MetricName("spans." + handle, "", "discarded")));
+    this.spanLogsDisabled = Pair.of(spanLogsFeatureDisabled,
+        Metrics.newCounter(new MetricName("spanLogs." + handle, "", "discarded")));
+
     this.scheduledExecutorService =
         Executors.newScheduledThreadPool(1, new NamedThreadFactory("otlp-grpc-heart-beater"));
     scheduledExecutorService.scheduleAtFixedRate(this, 1, 1, TimeUnit.MINUTES);
@@ -90,20 +107,34 @@ public class OtlpGrpcTraceHandler extends TraceServiceGrpc.TraceServiceImplBase 
                               @Nullable WavefrontSender wfSender,
                               @Nullable Supplier<ReportableEntityPreprocessor> preprocessorSupplier,
                               SpanSampler sampler,
+                              Supplier<Boolean> spansFeatureDisabled,
+                              Supplier<Boolean> spanLogsFeatureDisabled,
                               String defaultSource,
                               Set<String> traceDerivedCustomTagKeys) {
     this(handle, handlerFactory.getHandler(HandlerKey.of(ReportableEntityType.TRACE, handle)),
         handlerFactory.getHandler(HandlerKey.of(ReportableEntityType.TRACE_SPAN_LOGS, handle)),
-        wfSender, preprocessorSupplier, sampler, defaultSource, traceDerivedCustomTagKeys);
+        wfSender, preprocessorSupplier, sampler, spansFeatureDisabled, spanLogsFeatureDisabled,
+        defaultSource, traceDerivedCustomTagKeys);
   }
 
   @Override
   public void export(ExportTraceServiceRequest request,
                      StreamObserver<ExportTraceServiceResponse> responseObserver) {
+    long spanCount = OtlpProtobufUtils.getSpansCount(request);
+    receivedSpans.inc(spanCount);
+
+    if (isFeatureDisabled(spansDisabled._1, SPAN_DISABLED, spansDisabled._2, spanCount)) {
+      Status grpcError = Status.FAILED_PRECONDITION.augmentDescription(SPAN_DISABLED);
+      responseObserver.onError(grpcError.asException());
+      return;
+    }
+
     OtlpProtobufUtils.exportToWavefront(
-        request, spanHandler, spanLogsHandler, preprocessorSupplier, spanSamplerAndCounter,
-        defaultSource, discoveredHeartbeatMetrics, internalReporter, traceDerivedCustomTagKeys
+        request, spanHandler, spanLogsHandler, preprocessorSupplier, spanLogsDisabled,
+        spanSamplerAndCounter, defaultSource, discoveredHeartbeatMetrics, internalReporter,
+        traceDerivedCustomTagKeys
     );
+
     responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance());
     responseObserver.onCompleted();
   }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandler.java
@@ -42,6 +42,8 @@ import wavefront.report.SpanLogs;
 
 import static com.wavefront.agent.channel.ChannelUtils.errorMessageWithRootCause;
 import static com.wavefront.agent.channel.ChannelUtils.writeHttpResponse;
+import static com.wavefront.agent.listeners.FeatureCheckUtils.SPAN_DISABLED;
+import static com.wavefront.agent.listeners.FeatureCheckUtils.isFeatureDisabled;
 import static com.wavefront.internal.SpanDerivedMetricsUtils.TRACING_DERIVED_PREFIX;
 import static com.wavefront.internal.SpanDerivedMetricsUtils.reportHeartbeats;
 
@@ -58,6 +60,9 @@ public class OtlpHttpHandler extends AbstractHttpOnlyHandler implements Closeabl
   private final WavefrontSender sender;
   private final ReportableEntityHandler<SpanLogs, String> spanLogsHandler;
   private final Set<String> traceDerivedCustomTagKeys;
+  private final Counter receivedSpans;
+  private final Pair<Supplier<Boolean>, Counter> spansDisabled;
+  private final Pair<Supplier<Boolean>, Counter> spanLogsDisabled;
 
   public OtlpHttpHandler(ReportableEntityHandlerFactory handlerFactory,
                          @Nullable TokenAuthenticator tokenAuthenticator,
@@ -66,6 +71,8 @@ public class OtlpHttpHandler extends AbstractHttpOnlyHandler implements Closeabl
                          @Nullable WavefrontSender wfSender,
                          @Nullable Supplier<ReportableEntityPreprocessor> preprocessorSupplier,
                          SpanSampler sampler,
+                         Supplier<Boolean> spansFeatureDisabled,
+                         Supplier<Boolean> spanLogsFeatureDisabled,
                          String defaultSource,
                          Set<String> traceDerivedCustomTagKeys) {
     super(tokenAuthenticator, healthCheckManager, handle);
@@ -74,11 +81,17 @@ public class OtlpHttpHandler extends AbstractHttpOnlyHandler implements Closeabl
         handlerFactory.getHandler(HandlerKey.of(ReportableEntityType.TRACE_SPAN_LOGS, handle));
     this.sender = wfSender;
     this.preprocessorSupplier = preprocessorSupplier;
-    this.spanSamplerAndCounter = Pair.of(sampler,
-        Metrics.newCounter(new MetricName("spans." + handle, "", "sampler.discarded")));
     this.defaultSource = defaultSource;
     this.traceDerivedCustomTagKeys = traceDerivedCustomTagKeys;
+
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
+    this.receivedSpans = Metrics.newCounter(new MetricName("spans." + handle, "", "received.total"));
+    this.spanSamplerAndCounter = Pair.of(sampler,
+        Metrics.newCounter(new MetricName("spans." + handle, "", "sampler.discarded")));
+    this.spansDisabled = Pair.of(spansFeatureDisabled,
+        Metrics.newCounter(new MetricName("spans." + handle, "", "discarded")));
+    this.spanLogsDisabled = Pair.of(spanLogsFeatureDisabled,
+        Metrics.newCounter(new MetricName("spanLogs." + handle, "", "discarded")));
 
     this.scheduledExecutorService =
         Executors.newScheduledThreadPool(1, new NamedThreadFactory("otlp-http-heart-beater"));
@@ -103,9 +116,18 @@ public class OtlpHttpHandler extends AbstractHttpOnlyHandler implements Closeabl
     try {
       ExportTraceServiceRequest otlpRequest =
           ExportTraceServiceRequest.parseFrom(request.content().nioBuffer());
+      long spanCount = OtlpProtobufUtils.getSpansCount(otlpRequest);
+      receivedSpans.inc(spanCount);
+
+      if (isFeatureDisabled(spansDisabled._1, SPAN_DISABLED, spansDisabled._2, spanCount)) {
+        writeHttpResponse(ctx, HttpResponseStatus.ACCEPTED, SPAN_DISABLED, request);
+        return;
+      }
+
       OtlpProtobufUtils.exportToWavefront(
-          otlpRequest, spanHandler, spanLogsHandler, preprocessorSupplier, spanSamplerAndCounter,
-          defaultSource, discoveredHeartbeatMetrics, internalReporter, traceDerivedCustomTagKeys
+          otlpRequest, spanHandler, spanLogsHandler, preprocessorSupplier, spanLogsDisabled,
+          spanSamplerAndCounter, defaultSource, discoveredHeartbeatMetrics, internalReporter,
+          traceDerivedCustomTagKeys
       );
       /*
       We use HTTP 200 for success and HTTP 400 for errors, mirroring what we found in

--- a/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtils.java
@@ -127,11 +127,9 @@ public class OtlpProtobufUtils {
   //   wfSender. This could be more efficient, and also more reliable in the event the loops
   //   below throw an error and we don't report any of the list.
   @VisibleForTesting
-  static List<Pair<Span, SpanLogs>> fromOtlpRequest(
-      ExportTraceServiceRequest request,
-      @Nullable ReportableEntityPreprocessor preprocessor,
-      String defaultSource
-  ) {
+  static List<Pair<Span, SpanLogs>> fromOtlpRequest(ExportTraceServiceRequest request,
+                                                    @Nullable ReportableEntityPreprocessor preprocessor,
+                                                    String defaultSource) {
     List<Pair<Span, SpanLogs>> wfSpansAndLogs = Lists.newArrayList();
 
     for (ResourceSpans rSpans : request.getResourceSpansList()) {
@@ -254,7 +252,7 @@ public class OtlpProtobufUtils {
 
   @VisibleForTesting
   static SpanLogs transformEvents(io.opentelemetry.proto.trace.v1.Span otlpSpan,
-                                         Span wfSpan) {
+                                  Span wfSpan) {
     ArrayList<SpanLog> logs = new ArrayList<>();
 
     for (io.opentelemetry.proto.trace.v1.Span.Event event : otlpSpan.getEventsList()) {
@@ -281,7 +279,7 @@ public class OtlpProtobufUtils {
   // with the removal of the KeyValue determined to be the source.
   @VisibleForTesting
   static Pair<String, List<KeyValue>> sourceFromAttributes(List<KeyValue> otlpAttributes,
-                                                                  String defaultSource) {
+                                                           String defaultSource) {
     // Order of keys in List matters: it determines precedence when multiple candidates exist.
     List<String> candidateKeys = Arrays.asList(SOURCE_KEY, "host.name", "hostname", "host.id");
     Comparator<KeyValue> keySorter = Comparator.comparing(kv -> candidateKeys.indexOf(kv.getKey()));
@@ -354,11 +352,9 @@ public class OtlpProtobufUtils {
   }
 
   @VisibleForTesting
-  static Pair<Map<String, String>, String> reportREDMetrics(
-      Span span,
-      WavefrontInternalReporter internalReporter,
-      Set<String> traceDerivedCustomTagKeys
-  ) {
+  static Pair<Map<String, String>, String> reportREDMetrics(Span span,
+                                                            WavefrontInternalReporter internalReporter,
+                                                            Set<String> traceDerivedCustomTagKeys) {
     Map<String, String> annotations = mapFromAnnotations(span.getAnnotations());
     List<Pair<String, String>> spanTags = span.getAnnotations().stream()
         .map(a -> Pair.of(a.getKey(), a.getValue())).collect(Collectors.toList());
@@ -414,7 +410,7 @@ public class OtlpProtobufUtils {
 
   @VisibleForTesting
   static boolean shouldReportSpanLogs(int logsCount,
-                                              Pair<Supplier<Boolean>, Counter> spanLogsDisabled) {
+                                      Pair<Supplier<Boolean>, Counter> spanLogsDisabled) {
     return logsCount > 0 && !isFeatureDisabled(spanLogsDisabled._1, SPANLOGS_DISABLED,
         spanLogsDisabled._2, logsCount);
   }

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
@@ -70,6 +70,7 @@ public class OtlpGrpcTraceHandlerTest {
         null);
     otlpGrpcTraceHandler.export(otlpRequest, emptyStreamObserver);
     otlpGrpcTraceHandler.run();
+    otlpGrpcTraceHandler.close();
 
     // 3. Assert
     EasyMock.verify(mockSampler, mockSpanHandler, mockSpanLogsHandler, mockSender);

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpGrpcTraceHandlerTest.java
@@ -66,7 +66,8 @@ public class OtlpGrpcTraceHandlerTest {
 
     // 2. Act
     OtlpGrpcTraceHandler otlpGrpcTraceHandler = new OtlpGrpcTraceHandler("9876", mockSpanHandler,
-        mockSpanLogsHandler, mockSender, null, mockSampler, "test-source", null);
+        mockSpanLogsHandler, mockSender, null, mockSampler, () -> false, () -> false, "test-source",
+        null);
     otlpGrpcTraceHandler.export(otlpRequest, emptyStreamObserver);
     otlpGrpcTraceHandler.run();
 

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandlerTest.java
@@ -71,7 +71,7 @@ public class OtlpHttpHandlerTest {
     EasyMock.replay(mockSampler, mockSender, mockCtx);
 
     OtlpHttpHandler handler = new OtlpHttpHandler(mockHandlerFactory, null, null, "4318",
-        mockSender, null, mockSampler, "defaultSource", null);
+        mockSender, null, mockSampler, () -> false, () -> false, "defaultSource", null);
     io.opentelemetry.proto.trace.v1.Span otlpSpan =
         OtlpTestHelpers.otlpSpanGenerator().build();
     ExportTraceServiceRequest otlpRequest = OtlpTestHelpers.otlpTraceRequest(otlpSpan);

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpHttpHandlerTest.java
@@ -82,6 +82,7 @@ public class OtlpHttpHandlerTest {
 
     handler.handleHttpMessage(mockCtx, request);
     handler.run();
+    handler.close();
 
     EasyMock.verify(mockSampler, mockSender);
     HashMap<String, String> actualHeartbeatTags = heartbeatTagsCapture.getValue();

--- a/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/otlp/OtlpProtobufUtilsTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -78,6 +80,7 @@ import static org.junit.Assert.assertTrue;
  * @author Glenn Oppegard (goppegard@vmware.com).
  */
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*"})
 @PrepareForTest({SpanDerivedMetricsUtils.class, OtlpProtobufUtils.class})
 public class OtlpProtobufUtilsTest {
 
@@ -126,7 +129,7 @@ public class OtlpProtobufUtilsTest {
 
     // Act
     OtlpProtobufUtils.exportToWavefront(otlpRequest, mockSpanHandler, null, () -> mockPreprocessor,
-        null, "test-source", null, null, null);
+        null, null, "test-source", null, null, null);
 
     // Assert
     EasyMock.verify(mockPreprocessor, mockSpanHandler);
@@ -159,7 +162,7 @@ public class OtlpProtobufUtilsTest {
     Set<Pair<Map<String, String>, String>> discoveredHeartbeats = Sets.newConcurrentHashSet();
 
     OtlpProtobufUtils.exportToWavefront(otlpRequest, mockSpanHandler, null, null,
-        Pair.of(mockSampler, mockCounter), "test-source", discoveredHeartbeats, null, null);
+        null, Pair.of(mockSampler, mockCounter), "test-source", discoveredHeartbeats, null, null);
 
     // Assert
     EasyMock.verify(mockCounter, mockSampler, mockSpanHandler);
@@ -188,7 +191,7 @@ public class OtlpProtobufUtilsTest {
     Set<Pair<Map<String, String>, String>> discoveredHeartbeats = Sets.newConcurrentHashSet();
 
     OtlpProtobufUtils.exportToWavefront(otlpRequest, mockSpanHandler, null, null,
-        Pair.of(mockSampler, null), "test-source", discoveredHeartbeats, null, null);
+        null, Pair.of(mockSampler, null), "test-source", discoveredHeartbeats, null, null);
 
     // Assert
     EasyMock.verify(mockSampler, mockSpanHandler);
@@ -427,8 +430,8 @@ public class OtlpProtobufUtilsTest {
 
     actualSpan = OtlpProtobufUtils.transformSpan(otlpSpan, emptyAttrs, library, null, "test-source");
 
-    assertThat(actualSpan.getAnnotations(), hasItem(new Annotation("otel.library.name", "grpc")));
-    assertThat(actualSpan.getAnnotations(), hasItem(new Annotation("otel.library.version", "1.0")));
+    assertThat(actualSpan.getAnnotations(), hasItem(new Annotation("otel.scope.name", "grpc")));
+    assertThat(actualSpan.getAnnotations(), hasItem(new Annotation("otel.scope.version", "1.0")));
   }
 
   @Test
@@ -783,14 +786,14 @@ public class OtlpProtobufUtilsTest {
     InstrumentationLibrary library =
         InstrumentationLibrary.newBuilder().setName("net/http").build();
 
-    assertEquals(Collections.singletonList(new Annotation("otel.library.name", "net/http")),
+    assertEquals(Collections.singletonList(new Annotation("otel.scope.name", "net/http")),
         OtlpProtobufUtils.annotationsFromInstrumentationLibrary(library));
 
     library = library.toBuilder().setVersion("1.0.0").build();
 
     assertEquals(
-        Arrays.asList(new Annotation("otel.library.name", "net/http"),
-            new Annotation("otel.library.version", "1.0.0")),
+        Arrays.asList(new Annotation("otel.scope.name", "net/http"),
+            new Annotation("otel.scope.version", "1.0.0")),
         OtlpProtobufUtils.annotationsFromInstrumentationLibrary(library)
     );
   }
@@ -819,5 +822,22 @@ public class OtlpProtobufUtilsTest {
     assertThat(actual, hasItem(new Annotation("otel.dropped_attributes_count", "1")));
     assertThat(actual, hasItem(new Annotation("otel.dropped_events_count", "2")));
     assertThat(actual, hasItem(new Annotation("otel.dropped_links_count", "3")));
+  }
+
+  @Test
+  public void shouldReportSpanLogsFalseIfZeroLogs() {
+    assertFalse(OtlpProtobufUtils.shouldReportSpanLogs(0, null));
+  }
+
+  @Test
+  public void shouldReportSpanLogsFalseIfNonZeroLogsAndFeatureDisabled() {
+    Supplier<Boolean> spanLogsFeatureDisabled = () -> true;
+    assertFalse(OtlpProtobufUtils.shouldReportSpanLogs(1, Pair.of(spanLogsFeatureDisabled, null)));
+  }
+
+  @Test
+  public void shouldReportSpanLogsTrueIfNonZeroLogsAndFeatureEnabled() {
+    Supplier<Boolean> spanLogsFeatureDisabled = () -> false;
+    assertTrue(OtlpProtobufUtils.shouldReportSpanLogs(1, Pair.of(spanLogsFeatureDisabled, null)));
   }
 }


### PR DESCRIPTION
Always report `spans.<handle>.received.total`.

If distributed tracing is disabled at the cluster/tenant level, report `spans.<handle>.discarded`.

If span logs are disabled at the cluster/tentant level, report `spanLogs.<handle>.discarded`.